### PR TITLE
list and path

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,14 @@
 # frozen_string_literal: true
 
+begin
+  require "tocer/rake/register"
+rescue LoadError => error
+  puts error.message
+end
+
+Tocer::Rake::Register.call
+
+
 require "bundler/gem_tasks"
 require "rake/testtask"
 

--- a/examples/prompts_dir/toy/8-ball.txt
+++ b/examples/prompts_dir/toy/8-ball.txt
@@ -1,0 +1,4 @@
+# prompt_manager/examples/prompts_dir/toy/8-ball.txt
+# Desc: In the late 1940s the toy "Magic 8 Ball" came to market
+
+As a magic 8-ball, provide me with a terse answer to what you suspect that I am thinking about.

--- a/examples/simple.rb
+++ b/examples/simple.rb
@@ -13,11 +13,6 @@
 # TODO: Add `path` to get a path to the prompt file
 #
 
-require 'debug_me'
-include DebugMe
-
-debug_me "== before require =="
-
 require 'prompt_manager'
 require 'prompt_manager/storage/file_system_adapter'
 
@@ -37,8 +32,6 @@ at_exit do
   puts
 end
 
-debug_me "before config"
-
 # Configure the Storage Adapter to use
 PromptManager::Storage::FileSystemAdapter.config do |config|
   config.prompts_dir        = PROMPTS_DIR
@@ -47,11 +40,7 @@ PromptManager::Storage::FileSystemAdapter.config do |config|
   # config.parms+_extension = '.json' # default
 end
 
-debug_me "after config"
-
 PromptManager::Prompt.storage_adapter = PromptManager::Storage::FileSystemAdapter.new
-
-debug_me "after new"
 
 # Get a prompt
 
@@ -103,3 +92,51 @@ EOS
 
 puts todo.to_s
 
+puts <<~EOS
+
+  When using the FileSystemAdapter for prompt storage you can have within 
+  the prompts_dir you can have many sub-directories. These sub-directories 
+  act like categories.  The prompt ID is composed for the sub-directory name, 
+  a "/" character and then the normal prompt ID.  For example "toy/8-ball"
+
+EOS
+
+magic = PromptManager::Prompt.get( id: 'toy/8-ball' )
+
+puts "The magic PROMPT is:"
+puts magic
+puts
+puts "Remember if you want to see the full text of the prompt file:"
+puts magic.text
+
+puts "="*64
+
+puts <<~EOS
+
+  The FileSystemAdapter also adds two new methods to the Prompt class:
+
+    list - provides an Array of pompt IDs
+    path(prompt_id) - Returns a Pathname object to the prompt file
+
+EOS
+
+puts "List of prompts available"
+puts "========================="
+
+puts PromptManager::Prompt.list
+
+puts <<~EOS
+
+  And the path to the "toy/8-ball" prompt file is:
+
+  #{magic.path}
+
+  Use "your_prompt.path" for when you want to do something with the
+  the prompt file like send it to a text editor.
+
+  Your can also use the class method if you supply a prompt_id
+  like this:
+
+EOS
+
+puts PromptManager::Prompt.path('toy/8-ball')

--- a/examples/simple.rb
+++ b/examples/simple.rb
@@ -9,7 +9,14 @@
 ##  By:   Dewayne VanHoozer (dvanhoozer@gmail.com)
 ##
 #
+# TODO: Add `list` to get an Array of prompt IDs
+# TODO: Add `path` to get a path to the prompt file
+#
 
+require 'debug_me'
+include DebugMe
+
+debug_me "== before require =="
 
 require 'prompt_manager'
 require 'prompt_manager/storage/file_system_adapter'
@@ -30,12 +37,21 @@ at_exit do
   puts
 end
 
-# Configure the Storage Adapter to use
+debug_me "before config"
 
-PromptManager::Prompt.storage_adapter = 
-  PromptManager::Storage::FileSystemAdapter.new(
-    prompts_dir: PROMPTS_DIR
-  )
+# Configure the Storage Adapter to use
+PromptManager::Storage::FileSystemAdapter.config do |config|
+  config.prompts_dir        = PROMPTS_DIR
+  # config.search_proc      = nil     # default
+  # config.prompt_extension = '.txt'  # default
+  # config.parms+_extension = '.json' # default
+end
+
+debug_me "after config"
+
+PromptManager::Prompt.storage_adapter = PromptManager::Storage::FileSystemAdapter.new
+
+debug_me "after new"
 
 # Get a prompt
 

--- a/lib/prompt_manager/storage/file_system_adapter.rb
+++ b/lib/prompt_manager/storage/file_system_adapter.rb
@@ -1,26 +1,94 @@
 # prompt_manager/lib/prompt_manager/storage/file_system_adapter.rb
 
-
 require 'json'
+require 'pathname'
 
 class PromptManager::Storage::FileSystemAdapter
   PARAMS_EXTENSION = '.json'.freeze
   PROMPT_EXTENSION = '.txt'.freeze
 
-  attr_reader :prompts_dir
-
-  def initialize(
-      prompts_dir:  '.prompts',
-      search_proc:  nil   # Example: ->(q) {`ag -l #{q}`}
-    )
-
-    # validate that prompts_dir exist and is in fact a directory.
-    unless Dir.exist?(prompts_dir)
-      raise "Directory #{prompts_dir} does not exist or is not a directory"
+  class << self
+    attr_accessor :prompts_dir, :search_proc, 
+                  :params_extension, :prompt_extension
+  
+    def config
+      yield self
+      debug_me('== after block =='){[
+        :prompts_dir,
+        :search_proc,
+        :prompt_extension,
+        :params_extension
+      ]}
+      validate_configuration
     end
 
-    @prompts_dir  = prompts_dir
-    @search_proc  = search_proc
+
+    def list(...)
+      new.list
+    end
+
+    #################################################
+    private
+
+    def validate_configuration
+      validate_prompts_dir
+      validate_search_proc
+      validate_prompt_extension
+      validate_params_extension
+    end
+
+
+    def validate_prompts_dir
+      unless prompts_dir.is_a?(Pathname)
+        prompts_dir = Pathname.new(prompts_dir) unless prompts_dir.nil?
+      end
+
+      prompts_dir = prompts_dir.expand_path
+
+      raise(ArgumentError, "prompts_dir: #{prompts_dir}") unless prompts_dir.exist? && prompts_dir.directory?
+    end
+
+
+    def validate_search_proc
+      unless search_proc.nil?
+        raise(ArgumentError, "search_proc invalid; does not respond to call") unless search_proc.respond_to?(:call)
+      end
+    end
+
+
+    def validate_prompt_extension
+      if prompt_extension.nil?
+        prompt_extension = PROMPT_EXTENSION
+      else
+        unless  prompt_extension.is_a?(String)    &&
+                prompt_extension.start_with?('.')
+          raise(ArgumentError, "Invalid prompt_extension: #{prompt_extension}")
+        end
+      end
+    end
+
+
+    def validate_params_extension
+      if params_extension.nil?
+        params_extension = PARAMS_EXTENSION
+      else
+        unless  params_extension.is_a?(String)    &&
+                params_extension.start_with?('.')
+          raise(ArgumentError, "Invalid params_extension: #{params_extension}")
+        end
+      end
+    end
+  end
+
+
+  def prompts_dir       = self.class.prompts_dir
+  def search_proc       = self.class.search_proc
+  def prompt_extension  = self.class.prompt_extension
+  def params_extension  = self.class.params_extension
+
+
+  def initialize
+    self.class.validate_configuration
   end
 
 
@@ -37,13 +105,13 @@ class PromptManager::Storage::FileSystemAdapter
 
   # Retrieve prompt text by its id
   def prompt_text(prompt_id)
-    read_file(file_path(prompt_id, PROMPT_EXTENSION))
+    read_file(file_path(prompt_id, prompt_extension))
   end
 
 
   # Retrieve parameter values by its id
   def parameter_values(prompt_id)
-    json_content = read_file(file_path(prompt_id, PARAMS_EXTENSION))
+    json_content = read_file(file_path(prompt_id, params_extension))
     deserialize(json_content)
   end
 
@@ -56,8 +124,8 @@ class PromptManager::Storage::FileSystemAdapter
     )
     validate_id(id)
 
-    prompt_filepath = file_path(id, PROMPT_EXTENSION)
-    params_filepath = file_path(id, PARAMS_EXTENSION)
+    prompt_filepath = file_path(id, prompt_extension)
+    params_filepath = file_path(id, params_extension)
     
     write_with_error_handling(prompt_filepath, text)
     write_with_error_handling(params_filepath, serialize(parameters))
@@ -68,8 +136,8 @@ class PromptManager::Storage::FileSystemAdapter
   def delete(id:)
     validate_id(id)
 
-    prompt_filepath = file_path(id, PROMPT_EXTENSION)
-    params_filepath = file_path(id, PARAMS_EXTENSION)
+    prompt_filepath = file_path(id, prompt_extension)
+    params_filepath = file_path(id, params_extension)
     
     delete_with_error_handling(prompt_filepath)
     delete_with_error_handling(params_filepath)
@@ -85,26 +153,54 @@ class PromptManager::Storage::FileSystemAdapter
   end
 
 
+  # Return an Array of prompt IDs
+  def list(...)
+    prompt_ids = []
+    
+    Pathname.glob(prompts_dir.join("**/*#{prompt_extension}")).each do |file_path|
+      prompt_id = file_path.relative_path_from(prompts_dir).to_s.gsub(promt_extension, '')
+      prompt_ids << prompt_id
+    end
+
+    prompt_ids
+  end
+
+
+  # Returns a Pathname object for a prompt ID text file
+  # However, it is possible that the file does not exist.
+  def path(id)
+    validate_id(id)
+    file_path(id, prompt_extension) 
+  end
+
   ##########################################
   private
 
+  # Validate that the ID contains good characters.
   def validate_id(id)
     raise ArgumentError, 'Invalid ID format' unless id =~ /^[a-zA-Z0-9\-_]+$/
   end
 
 
+  # Verify that the ID actually exists
+  def verify_id(id)
+    file_path(id, prompt_extension).exist?
+  end
+
+
   def write_with_error_handling(file_path, content)
     begin
-      File.write(file_path, content)
+      file_path.write content
     rescue IOError => e
       raise "Failed to write to file: #{e.message}"
     end
   end
 
 
+  # file_path (Pathname)
   def delete_with_error_handling(file_path)
     begin
-      FileUtils.rm_f(file_path)
+      file_path.delete
     rescue IOError => e
       raise "Failed to delete file: #{e.message}"
     end
@@ -112,7 +208,7 @@ class PromptManager::Storage::FileSystemAdapter
 
 
   def file_path(id, extension)
-    File.join(@prompts_dir, "#{id}#{extension}")
+    prompts_dir + "#{id}#{extension}"
   end
 
 
@@ -123,20 +219,21 @@ class PromptManager::Storage::FileSystemAdapter
 
 
   def search_prompts(search_term)
-    query_term = search_term.downcase
-
-    Dir.glob(File.join(@prompts_dir, "*#{PROMPT_EXTENSION}")).each_with_object([]) do |file_path, ids|
-      File.open(file_path) do |file|
-        file.each_line do |line|
-          if line.downcase.include?(query_term)
-            ids << File.basename(file_path, PROMPT_EXTENSION)
-            next
-          end
-        end
+    prompt_ids = []
+    
+    Pathname.glob(prompts_dir.join("**/*#{prompt_extension}")).each do |prompt_path|
+      if prompt_path.read.downcase.include?(search_term)
+        prompt_id = prompt_path.relative_path_from(prompts_dir).to_s.gsub(prompt_extension, '')    
+        prompt_ids << prompt_id
       end
-    end.uniq
+    end
+
+    prompt_ids
+
   end
 
+
+  # TODO: Should the serializer be generic?
 
   def serialize(data)
     data.to_json
@@ -147,3 +244,207 @@ class PromptManager::Storage::FileSystemAdapter
     JSON.parse(data)
   end
 end
+
+__END__
+
+require 'debug_me'
+include DebugMe
+
+require 'amazing_print'
+require 'pathname'
+
+class MyClass
+  PARAMS_EXTENSION = '.json'.freeze
+  PROMPT_EXTENSION = '.txt'.freeze
+
+  class << self
+    attr_accessor :prompts_dir, :search_proc,
+                  :params_extension, :prompt_extension
+
+    def config(&block)
+      if block_given?
+        self.class_eval(&block) # yield self
+      else
+        puts "ERROR: No config block"
+        exit(1)
+      end
+
+      debug_me('== after block =='){[
+        :prompts_dir,
+        :search_proc,
+        :prompt_extension,
+        :params_extension
+      ]}
+
+      validate_configuration
+    end
+
+    def list(...)
+      new.list
+    end
+
+
+    private
+
+    def validate_configuration
+      debug_me("=== validate =="){[
+        :prompts_dir,
+        :search_proc,
+        :prompt_extension,
+        :params_extension
+      ]}
+
+      validate_prompts_dir        # ; rescue => e; puts "\n\nERROR: #{e.message}"
+      validate_search_proc        # ; rescue => e; puts "\n\nERROR: #{e.message}"
+      validate_prompt_extension   # ; rescue => e; puts "\n\nERROR: #{e.message}"
+      validate_params_extension   # ; rescue => e; puts "\n\nERROR: #{e.message}"
+    end
+
+    def validate_prompts_dir
+      prompts_dir_local = prompts_dir.dup
+
+      debug_me("=== INSIDE tdv_validate_prompts_dir =="){[
+        :prompts_dir,
+        :prompts_dir_local,
+        :search_proc,
+        :prompt_extension,
+        :params_extension
+      ]}
+
+
+      unless prompts_dir_local.is_a?(Pathname)
+        prompts_dir_local = Pathname.new(prompts_dir_local) unless prompts_dir_local.nil?
+      end
+
+      prompts_dir_local = prompts_dir_local.expand_path
+
+      raise(ArgumentError, "prompts_dir: #{prompts_dir_local}") unless prompts_dir_local.exist? && prompts_dir.directory?
+    
+      prompts_dir = prompts_dir_local
+
+      debug_me{[
+        :prompts_dir,
+        :prompts_dir_local
+      ]}
+    end
+
+
+    def validate_search_proc
+      search_proc_local = search_proc.dup
+
+      debug_me("=== INSIDE tdv_validate_search_proc =="){[
+        :prompts_dir,
+        :search_proc,
+        :search_proc_local,
+        :prompt_extension,
+        :params_extension
+      ]}
+
+
+      unless search_proc_local.nil?
+        raise(ArgumentError, "search_proc invalid; does not respond to call") unless search_proc_local.respond_to?(:call)
+      end
+
+      search_proc = search_proc_local
+    end
+
+
+    def validate_prompt_extension
+      prompt_extension_local = prompt_extension.dup
+
+      debug_me("=== INSIDE tdv_validate_search_proc =="){[
+        :prompts_dir,
+        :search_proc,
+        :prompt_extension,
+        :prompt_extension_local,
+        :params_extension
+      ]}
+
+
+      if prompt_extension_local.nil?
+        prompt_extension_local = PROMPT_EXTENSION
+      else
+        unless  prompt_extension_local.is_a?(String)    &&
+                prompt_extension_local.start_with?('.')
+          raise(ArgumentError, "Invalid prompt_extension: #{prompt_extension_local}")
+        end
+      end
+      prompt_extension = prompt_extension_local
+    end
+
+
+    def validate_params_extension
+      params_extension_local = params_extension.dup
+
+      debug_me("=== INSIDE tdv_validate_search_proc =="){[
+        :prompts_dir,
+        :search_proc,
+        :prompt_extension,
+        :params_extension,
+        :params_extension_local
+      ]}
+
+
+      if params_extension_local.nil?
+        params_extension_local = PARAMS_EXTENSION
+      else
+        unless  params_extension_local.is_a?(String)    &&
+                params_extension_local.start_with?('.')
+          raise(ArgumentError, "Invalid params_extension: #{params_extension_local}")
+        end
+      end
+
+      params_extension = params_extension_local
+    end
+  end
+
+
+  ##########################################
+  ###
+  ##  Instance methods
+  #
+
+  # Instance-level getters that proxy to the class-level variables
+  def prompts_dir       = self.class.prompts_dir
+  def search_proc       = self.class.search_proc
+  def prompt_extension  = self.class.prompt_extension
+  def params_extension  = self.class.params_extension
+  
+  def initialize
+    # TODO: What?
+  end
+
+  def list(...)
+    ap prompts_dir.children
+  end
+
+  # Instance method `hello` without using `self.class` prefix
+  def hello
+    puts prompts_dir
+    puts search_proc.call('winning lotto ticket') # Assuming `search_proc` is a Proc/Lambda object
+  
+    debug_me{[
+      :prompt_extension,
+      :params_extension
+    ]}
+
+  end
+end
+
+# Using the DSL for configuration
+MyClass.config do |option|
+  option.prompts_dir      = Pathname.new(ENV['HOME']) + '.prompts'
+  option.search_proc      = -> (q) { "find #{q} yourself"; [] }
+  option.prompt_extension = ".docx"
+  option.params_extension = ".yml"
+end
+
+# Instantiate MyClass and call the `hello` method
+i = MyClass.new
+i.hello
+i.list
+puts "======"
+MyClass.list
+
+
+

--- a/lib/prompt_manager/version.rb
+++ b/lib/prompt_manager/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PromptManager
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/prompt_manager.gemspec
+++ b/prompt_manager.gemspec
@@ -45,6 +45,6 @@ Gem::Specification.new do |spec|
   # spec.add_dependency "sqlite3"
 
   spec.add_development_dependency 'amazing_print'
-  spec.add_development_dependency "fakefs"
+  spec.add_development_dependency 'debug_me'
   spec.add_development_dependency "minitest"
 end

--- a/prompt_manager.gemspec
+++ b/prompt_manager.gemspec
@@ -47,4 +47,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'amazing_print'
   spec.add_development_dependency 'debug_me'
   spec.add_development_dependency "minitest"
+  spec.add_development_dependency 'tocer'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+require 'pathname'
+
+$TEST_DIR     = Pathname.new(__dir__)
+$PROMPTS_DIR  = $TEST_DIR + "../examples/prompts_dir"
+
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "prompt_manager"
 


### PR DESCRIPTION
- snapshot; adding forwarding of messages not handled by the Prompt class to the storage adaptor; adding a config block to the FileSystemAdaptor class but ran into a ruby error which looks like its confusing class methods with local variables.  Have a work around past the end of the file which has not yet been moved into the class.
- implemented config block for FileSystemAdapter; added "list" and "path" methods; fixed problem processing prompts in sub-directories
- updated the test suite for the new functionality in the FileStorageAdapter.  This includes adding a "extra" method fo the mock of a file system adapter for the prompt_test.rb file
- updated the README file; ready for PR
