### PR TITLE
Search proc example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+## [0.3.3] = 2023-12-01
+- Added example of using the `search_proc` config parameter with the FileSystemAdapter.
+
 ## [0.3.2] = 2023-12-01
 
 - The ActiveRecordAdapter is passing its unit tests

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ If bundler is not being used to manage dependencies, install the gem by executin
 
 See [examples/simple.rb](examples/simple.rb)
 
+See also [examples/using_search_proc.rb](examples/using_search_proc.rb)
+
 ## Overview
 
 ### Generative AI (gen-AI)
@@ -110,9 +112,11 @@ An `ArgumentError` will be raised when `prompts_dir` does not exist or if it is 
 
 ##### search_proc
 
-The default for `search_proc` is nil.  In this case the search will be preformed by a default `search` method which is basically reading all the prompt files to see which ones contain the search term.  There are faster ways to do this kind of thing using CLI-based utilities.
+The default for `search_proc` is nil which means that the search will be preformed by a default `search` method which is basically reading all the prompt files to see which ones contain the search term. It will return an Array of prompt IDs for each prompt file found that contains the search term.  Its up to the application to select which returned prompt ID to use. 
 
-TODO: add a example to the examples directory on how to integrate with command line utilities.
+There are faster ways to search and select files.  For example there are specialized search and selection utilities that are available for the command line. The `examples` directory contains a `bash` script named `rgfzf` that uses `rg` (aka `ripgrep`) to do the searching and `fzf` to do the selecting.
+
+See [examples/using_search_proc.rb](examples/using_search_proc.rb)
 
 ##### File Extensions
 

--- a/examples/rgfzf
+++ b/examples/rgfzf
@@ -21,14 +21,16 @@ selected_file=$(
   rg  --files-with-matches \
       --no-messages \
       --smart-case "$search_term" "$directory_path" |
+  sed "s#^$directory_path/##" | # Strip out the directory path
   fzf --ansi \
       --color "hl:-1:underline,hl+:-1:underline:reverse" \
-      --preview "cat {}" \
+      --preview "cat $directory_path/{}" \
       --preview-window "up,60%,border-bottom" \
       --no-multi \
       --exit-0 \
       --query "$search_term"
 )
+
 
 # If no file was selected, exit the script
 if [[ -z "$selected_file" ]]; then
@@ -36,7 +38,7 @@ if [[ -z "$selected_file" ]]; then
   exit 0
 fi
 
-# Remove the file extension and replace the initial part of the path
-prompt_id=$(echo "$selected_file" | sed "s#^$directory_path/##;s/\.[^.]*$//")
+# Remove the file extension
+prompt_id=$(echo "$selected_file" | sed "s/\.[^.]*$//")
 
 echo "$prompt_id"

--- a/examples/simple.rb
+++ b/examples/simple.rb
@@ -9,9 +9,6 @@
 ##  By:   Dewayne VanHoozer (dvanhoozer@gmail.com)
 ##
 #
-# TODO: Add `list` to get an Array of prompt IDs
-# TODO: Add `path` to get a path to the prompt file
-#
 
 require 'prompt_manager'
 require 'prompt_manager/storage/file_system_adapter'
@@ -140,3 +137,23 @@ puts <<~EOS
 EOS
 
 puts PromptManager::Prompt.path('toy/8-ball')
+
+puts
+
+puts "Default Search for Prompts"
+puts "=========================="
+
+print "Search Proc Class: "
+puts PromptManager::Prompt.storage_adapter.search_proc.class
+
+search_term = "txt"  # some comment lines show the file name example: todo.txt
+
+puts "Search for '#{search_term}' ..."
+
+prompt_ids = PromptManager::Prompt.search search_term
+
+# NOTE: prompt+ids is an Array of prompt IDs even if there is only one entry.
+#       or and empty array if there are no prompts have the search term.
+
+puts "Found: #{prompt_ids}"
+

--- a/examples/using_search_proc.rb
+++ b/examples/using_search_proc.rb
@@ -60,5 +60,12 @@ prompt_id = PromptManager::Prompt.search search_term
 #       case only one selected prompt ID that matches the search
 #       term will be returned.
 
-puts "Found: #{prompt_id}"
+puts "Found: '#{prompt_id}' which is a #{prompt_id.class}. empty? #{prompt_id.empty?}"
+
+puts <<~EOS
+  
+  When the rgfzf bash script does not find a prompt ID or if the 
+  ESC key is pressed, the prompt ID that is returned will be an empty String.
+
+EOS
 

--- a/examples/using_search_proc.rb
+++ b/examples/using_search_proc.rb
@@ -1,0 +1,64 @@
+#!/usr/bin/env ruby
+# encoding: utf-8
+# frozen_string_literal: true
+# warn_indent: true
+##########################################################
+###
+##  File: using_search_proc.rb
+##  Desc: Simple demo of the PromptManager and FileStorageAdapter
+##  By:   Dewayne VanHoozer (dvanhoozer@gmail.com)
+##
+#
+
+require 'debug_me'
+include DebugMe
+
+require 'prompt_manager'
+require 'prompt_manager/storage/file_system_adapter'
+
+require 'amazing_print'
+require 'pathname'
+
+HERE          = Pathname.new( __dir__ )
+PROMPTS_DIR   = HERE + "prompts_dir"
+SEARCH_SCRIPT = HERE + 'rgfzf'  # a bash script using rg and fzf
+
+######################################################
+# Main
+
+at_exit do
+  puts
+  puts "Done."
+  puts
+end
+
+# Configure the Storage Adapter to use
+PromptManager::Storage::FileSystemAdapter.config do |config|
+  config.prompts_dir        = PROMPTS_DIR
+  config.search_proc        = ->(q) {`#{SEARCH_SCRIPT} #{q} #{PROMPTS_DIR}`}     # default
+  # config.prompt_extension = '.txt'  # default
+  # config.parms+_extension = '.json' # default
+end
+
+PromptManager::Prompt.storage_adapter = PromptManager::Storage::FileSystemAdapter.new
+
+
+
+puts "Using Custom Search Proc"
+puts "========================"
+
+print "Search Proc Class: "
+puts PromptManager::Prompt.storage_adapter.search_proc.class
+
+search_term = "txt"  # some comment lines show the file name example: todo.txt
+
+puts "Search for '#{search_term}' ..."
+
+prompt_id = PromptManager::Prompt.search search_term
+
+# NOTE: the search proc uses fzf as a selection tool.  In this
+#       case only one selected prompt ID that matches the search
+#       term will be returned.
+
+puts "Found: #{prompt_id}"
+

--- a/lib/prompt_manager/storage/file_system_adapter.rb
+++ b/lib/prompt_manager/storage/file_system_adapter.rb
@@ -211,8 +211,8 @@ class PromptManager::Storage::FileSystemAdapter
   def search(for_what)
     search_term = for_what.downcase
 
-    if @search_proc
-      @search_proc.call(search_term)
+    if search_proc.is_a? Proc
+      search_proc.call(search_term)
     else
       search_prompts(search_term)
     end

--- a/lib/prompt_manager/version.rb
+++ b/lib/prompt_manager/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PromptManager
-  VERSION = "0.3.2"
+  VERSION = "0.3.3"
 end

--- a/test/prompt_manager/storage/file_system_adapter_test.rb
+++ b/test/prompt_manager/storage/file_system_adapter_test.rb
@@ -142,18 +142,21 @@ class FileSystemAdapterTest < Minitest::Test
   ############################################
   def test_search_proc
     search_term = "MadBomber"
+    saved_search_proc = @adapter.class.search_proc
 
     # search_proc is a way to use command line tools like
     # grep, rg, aq, ack, etc or anything else that makes
     # sense that will return a list of prompt IDs.
     # In the case of the FileSystemAdapter the ID is
     # the basename of the file snns its extension.
-    @adapter.instance_variable_set(:@search_proc, ->(q) { ["hello #{q}"] })
+    @adapter.class.search_proc = ->(q) { ["hello #{q}"] }
     
     expected  = ["hello madbomber"] # NOTE: query term is all lowercase
     results   = @adapter.search(search_term)
 
-    assert_equal results, expected
+    assert_equal expected, results
+
+    @adapter.class.search_proc = saved_search_proc
   end
 
 


### PR DESCRIPTION
tweaked the `rgfzf` bash script in the examples directory.  Add a default search demo to the simple.rb file.

created a using_search_proc.rb example.

