### PR TITLE
Update prompt_manager to version 0.5.1 and enhance parameter handling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    prompt_manager (0.5.0)
+    prompt_manager (0.5.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/prompt_manager/prompt.rb
+++ b/lib/prompt_manager/prompt.rb
@@ -123,7 +123,7 @@ class PromptManager::Prompt
   def substitute_values(input_text, values_hash)
     if values_hash.is_a?(Hash) && !values_hash.empty?
       values_hash.each do |key, value|
-        input_text = input_text.gsub(key, value)
+        input_text = input_text.gsub(key, value.last)
       end
     end
     input_text

--- a/lib/prompt_manager/storage/file_system_adapter.rb
+++ b/lib/prompt_manager/storage/file_system_adapter.rb
@@ -181,14 +181,28 @@ class PromptManager::Storage::FileSystemAdapter
 
   # Retrieve parameter values by its id
   def parameter_values(prompt_id)
-    params_path = file_path(prompt_id, params_extension)
+    # Parse parameters from the prompt text
+    prompt_text_content = prompt_text(prompt_id)
+    parsed_parameters = parse_parameters_from_text(prompt_text_content)
 
-    if params_path.exist?
-      parms_content = read_file(params_path)
-      deserialize(parms_content)
-    else
-      {}
+    # Load parameters from JSON file if it exists
+    params_path = file_path(prompt_id, params_extension)
+    file_parameters = params_path.exist? ? deserialize(read_file(params_path)) : {}
+
+    # Merge parsed parameters with file parameters
+    parsed_parameters.merge(file_parameters)
+  end
+
+  # Parse parameters from the prompt text
+  def parse_parameters_from_text(text)
+    parameters = {}
+
+    text.scan(PromptManager::Prompt.parameter_regex).each do |match|
+      variable_name = match.shift
+      parameters[variable_name] = [] unless parameters.key?(variable_name)
     end
+
+    parameters
   end
 
   # Save prompt text and parameter values to corresponding files

--- a/lib/prompt_manager/version.rb
+++ b/lib/prompt_manager/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PromptManager
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end


### PR DESCRIPTION
This commit updates the prompt_manager dependency to version 0.5.1
and introduces improvements in the handling of parameters within the
PromptManager class. Specifically, it modifies the
substitute_values method to replace input text values with the last
item in the array rather than the first.

Additionally, the parameter_values method has been enhanced to merge
parsed parameters from the prompt text with those loaded from a
JSON file, improving data retrieval and ensuring all parameters are
considered.

These changes aim to increase the flexibility and reliability of
parameter management and improve overall system functionality.
